### PR TITLE
Atualizar parser para novo layout de faturas CPFL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Diretórios (opcional)
+#CPFL_INBOX_DIR=data/incoming
+#CPFL_ARCHIVE_DIR=data/archive
+#CPFL_OUTPUT_DIR=data/output

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.env
+config/clients_config.json
+data/incoming/
+data/archive/
+data/output/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,145 @@
-# CPFL_Contas
+# CPFL Contas - Pipeline Automático de Extração de Faturas
+
+Pipeline completo em Python para consolidar faturas de energia da CPFL Energia a partir de PDFs depositados em pastas monitoradas. A solução suporta múltiplos clientes, valida e deduplica faturas e gera planilha-mestre, arquivos JSON por fatura e logs de resumo.
+
+## Visão geral da abordagem
+
+1. **Entrada**: PDFs das faturas em pastas por cliente (ex.: sincronizadas manualmente, via download automático ou anexos de e-mail). Cada cliente tem uma pasta de entrada configurável.
+2. **Processamento**: Script `python main.py sync` percorre as pastas, lê os PDFs com `pdfplumber`, extrai campos-chave via expressões regulares e normaliza datas/valores.
+3. **Validação & Deduplicação**: Regras básicas garantem que valores e datas são válidos. A chave `hash_fatura = MD5(numero_instalacao|mes_referencia|valor_total)` evita duplicidades.
+4. **Saída**: 
+   - `data/output/cpfl_faturas_master.csv` com uma linha por fatura.
+   - `data/output/cpfl_faturas_master.xlsx`.
+   - `data/output/json/<hash>.json` para auditoria.
+   - Arquivos PDF processados são movidos para `data/archive/`.
+
+Os mocks em `data/mocks/` permitem testar sem credenciais reais.
+
+## Pré-requisitos
+
+- Python 3.10+
+- Tesseract OCR opcional (somente se precisar adaptar para PDFs imagem; não é necessário para os mocks incluídos).
+
+## Instalação
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+```
+
+## Configuração
+
+1. Copie os exemplos de configuração:
+   ```bash
+   cp .env.example .env
+   cp config/clients_config.sample.json config/clients_config.json
+   ```
+2. Edite `config/clients_config.json` preenchendo os dados de cada cliente e a pasta de entrada dos PDFs. Exemplo:
+   ```json
+   {
+     "clientes": [
+       {
+         "cliente": "Cliente XPTO",
+         "numero_instalacao": "1234567",
+         "numero_cliente": "7654321",
+         "login": "USUARIO_PORTAL",
+         "senha": "SENHA_PORTAL",
+         "cpf4": "1234",
+         "pasta_entrada": "data/incoming/cliente_xpto"
+       }
+     ]
+   }
+   ```
+   - Deixe `login`, `senha`, `cpf4` vazios se não usar autenticação automática.
+   - A pasta informada precisa existir; o script cria subpastas automaticamente ao rodar.
+3. Ajuste `.env` se desejar alterar diretórios padrão (`CPFL_INBOX_DIR`, `CPFL_ARCHIVE_DIR`, `CPFL_OUTPUT_DIR`).
+
+## Runner (execução ponta a ponta)
+
+```bash
+python main.py sync
+```
+
+Logs são exibidos no console. No final é apresentado um resumo com contagem de faturas novas, atualizadas e ignoradas.
+
+## Estrutura dos dados de saída
+
+### Colunas da tabela-mestre (`cpfl_faturas_master.csv`)
+
+| Coluna | Formato | Descrição |
+|--------|---------|-----------|
+| `cliente` | texto | Nome de referência do cliente. |
+| `numero_instalacao` | texto numérico sem máscara | ID da instalação (somente dígitos). |
+| `numero_cliente` | texto numérico sem máscara | ID do cliente (somente dígitos). |
+| `mes_referencia` | `MM/AAAA` | Mês de competência da fatura. |
+| `vencimento` | `DD/MM/AAAA` | Data de vencimento normalizada. |
+| `valor_total` | decimal com ponto (`123.45`) | Valor total da fatura. |
+| `consumo_kwh` | decimal com ponto | Consumo medido em kWh. |
+| `quantidade_faturada` | decimal com ponto | Quantidade faturada (kWh) informada no quadro "Quant. Faturada". |
+| `tarifa_com_tributos` | decimal com ponto (5 casas) | Tarifa completa aplicada (R$/kWh) do campo "Tarifa com Tributos". |
+| `valor_total_operacao` | decimal com ponto (`123.45`) | Valor total da operação conforme demonstrativo fiscal. |
+| `bandeira_tarifaria` | texto | Bandeira tarifária informada. |
+| `tusd` | decimal com ponto | Valor de TUSD. |
+| `te` | decimal com ponto | Valor de TE. |
+| `icms` | decimal com ponto | Valor de ICMS. |
+| `pis_cofins` | decimal com ponto | Valor de PIS/COFINS. |
+| `endereco_uc` | texto | Endereço da unidade consumidora. |
+| `link_pdf` | texto | Link original, se extraído. |
+| `hash_fatura` | texto | Hash MD5 `numero_instalacao|mes_referencia|valor_total`. |
+| `status_pagamento` | texto | Status informado (Pago/Em aberto etc.). |
+| `arquivo_origem` | texto | Caminho do PDF processado (já movido para o arquivo). |
+
+### JSON por fatura
+
+Para cada linha, há um arquivo em `data/output/json/<hash>.json` com os mesmos campos acima.
+
+## Mocks para testes offline
+
+- `data/mocks/cliente_teste/` contém três PDFs fictícios representando faturas CPFL com dados verossímeis, incluindo um modelo atualizado com campos "Conta/Mês", "Quant. Faturada", "Tarifa com Tributos" e "Valor Total da Operação".
+- Para testar:
+  ```bash
+  mkdir -p data/incoming/cliente_teste
+  cp data/mocks/cliente_teste/*.pdf data/incoming/cliente_teste/
+  python main.py sync
+  ```
+  O pipeline processa os arquivos fictícios e gera a saída completa, permitindo validação sem credenciais.
+
+## Verificações automáticas
+
+- Validação de duplicidade por `hash_fatura`.
+- Checks básicos: `valor_total > 0`, `consumo_kwh >= 0`, datas válidas.
+- Log final resume contagem de faturas novas/atualizadas/ignoradas.
+
+## Instruções para produção
+
+1. Obtenha as credenciais de acesso ao portal CPFL ou configure a coleta de PDFs (ex.: download automático via Playwright, app de e-mail, etc.) alimentando as pastas de entrada.
+2. Preencha `.env` e `config/clients_config.json` com dados reais (login/senha/cpf4 se for automatizar o download; mantenha-os fora de logs).
+3. Programe uma rotina (cron, agendador do sistema, tarefas do Windows) para executar `python main.py sync` conforme desejado.
+4. Os relatórios consolidados ficam em `data/output/` e os PDFs processados em `data/archive/`.
+
+## Troubleshooting
+
+| Problema | Possível causa | Solução |
+|----------|----------------|---------|
+| Campos não extraídos | Layout diferente do PDF | Ajuste regex em `cpfl/pdf_parser.py` ou considere OCR com Tesseract (`pytesseract`) se o PDF for imagem. |
+| Datas/valores inválidos | Texto com formatação atípica | Revise o PDF; adicione regex extra ou normalização em `cpfl/utils.py`. |
+| Captcha no portal | Bloqueio de automação | Reforçar coleta via e-mail ou baixar manualmente e depositar na pasta. |
+| IMAP bloqueado | Segurança do provedor | Habilite senhas de app ou use OAuth. |
+| Timeout em download automático | Instabilidade do site | Implementar retries/backoff caso adicione automação de coleta. |
+
+## Segurança e LGPD
+
+- Guarde `.env` e `config/clients_config.json` fora de versionamento (já listados em `.gitignore`).
+- Defina permissões de pasta restritas para proteger credenciais.
+- Os logs são direcionados ao console; redirecione para arquivo seguro se necessário.
+- Não exponha `login`, `senha` ou CPF em prints/logs. O código evita registro desses valores.
+
+## Desenvolvimento futuro
+
+- É possível adicionar módulo Playwright ou Selenium usando as mesmas configurações de cliente.
+- Para PDFs escaneados, integre OCR com `pytesseract` e `pdf2image`.
+
+## Licença
+
+Projeto de referência interno para automação de leitura de faturas CPFL.

--- a/config/clients_config.sample.json
+++ b/config/clients_config.sample.json
@@ -1,0 +1,24 @@
+{
+  "clientes": [
+    {
+      "cliente": "Cliente Teste",
+      "numero_instalacao": "1234567890",
+      "numero_cliente": "9876543210",
+      "email_cliente": "cliente@example.com",
+      "login": "USUARIO_CPFL",
+      "senha": "SENHA_CPFL",
+      "cpf4": "1234",
+      "pasta_entrada": "data/incoming/cliente_teste"
+    },
+    {
+      "cliente": "Empresa ABC",
+      "numero_instalacao": "555666777",
+      "numero_cliente": "111222333",
+      "email_cliente": "financeiro@empresa.com",
+      "login": "LOGIN_EMPRESA",
+      "senha": "SENHA_EMPRESA",
+      "cpf4": "4321",
+      "pasta_entrada": "data/incoming/empresa_abc"
+    }
+  ]
+}

--- a/cpfl/__init__.py
+++ b/cpfl/__init__.py
@@ -1,0 +1,9 @@
+"""CPFL invoice processing package."""
+
+__all__ = [
+    "config",
+    "pdf_parser",
+    "pipeline",
+    "storage",
+    "utils",
+]

--- a/cpfl/config.py
+++ b/cpfl/config.py
@@ -1,0 +1,134 @@
+"""Configuration helpers for CPFL pipeline."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from dotenv import load_dotenv
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ClientConfig:
+    """Configuration for a single client installation."""
+
+    cliente: str
+    numero_instalacao: str
+    numero_cliente: Optional[str]
+    email_cliente: Optional[str]
+    login: Optional[str]
+    senha: Optional[str]
+    cpf4: Optional[str]
+    pasta_entrada: Optional[str]
+
+    @property
+    def slug(self) -> str:
+        return self.cliente.lower().replace(" ", "_")
+
+
+@dataclass
+class AppConfig:
+    """Top level configuration for the pipeline."""
+
+    inbox_dir: Path
+    archive_dir: Path
+    output_dir: Path
+    config_path: Path
+
+    @property
+    def json_output_dir(self) -> Path:
+        return self.output_dir / "json"
+
+    @property
+    def master_table_path(self) -> Path:
+        return self.output_dir / "cpfl_faturas_master.csv"
+
+    @property
+    def master_excel_path(self) -> Path:
+        return self.output_dir / "cpfl_faturas_master.xlsx"
+
+
+DEFAULT_CONFIG_LOCATIONS: Iterable[Path] = (
+    Path("config/clients_config.json"),
+    Path("config/clients_config.sample.json"),
+)
+
+
+def load_environment() -> None:
+    """Load environment variables from .env if present."""
+
+    env_path = Path(".env")
+    if env_path.exists():
+        load_dotenv(dotenv_path=env_path)
+        LOGGER.debug("Environment variables loaded from %s", env_path)
+    else:
+        load_dotenv()
+        LOGGER.debug("Environment variables loaded from default search path")
+
+
+def resolve_app_config(config_path: Optional[str] = None) -> AppConfig:
+    """Build application configuration from environment and defaults."""
+
+    load_environment()
+
+    inbox = Path(os.getenv("CPFL_INBOX_DIR", "data/incoming"))
+    archive = Path(os.getenv("CPFL_ARCHIVE_DIR", "data/archive"))
+    output = Path(os.getenv("CPFL_OUTPUT_DIR", "data/output"))
+
+    if config_path:
+        config_file = Path(config_path)
+    else:
+        for candidate in DEFAULT_CONFIG_LOCATIONS:
+            if candidate.exists():
+                config_file = candidate
+                break
+        else:
+            raise FileNotFoundError(
+                "Nenhum arquivo de configuração encontrado. Crie config/clients_config.json a partir do sample."
+            )
+
+    archive.mkdir(parents=True, exist_ok=True)
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "json").mkdir(parents=True, exist_ok=True)
+
+    return AppConfig(
+        inbox_dir=inbox,
+        archive_dir=archive,
+        output_dir=output,
+        config_path=config_file,
+    )
+
+
+def load_clients(config_path: Path) -> List[ClientConfig]:
+    """Load client definitions from JSON file."""
+
+    with config_path.open("r", encoding="utf-8") as fp:
+        payload: Dict[str, List[Dict[str, Optional[str]]]] = json.load(fp)
+
+    clients: List[ClientConfig] = []
+    for entry in payload.get("clientes", []):
+        clients.append(
+            ClientConfig(
+                cliente=entry.get("cliente", ""),
+                numero_instalacao=str(entry.get("numero_instalacao", "")),
+                numero_cliente=(entry.get("numero_cliente") or None),
+                email_cliente=(entry.get("email_cliente") or None),
+                login=(entry.get("login") or None),
+                senha=(entry.get("senha") or None),
+                cpf4=(entry.get("cpf4") or None),
+                pasta_entrada=(entry.get("pasta_entrada") or None),
+            )
+        )
+
+    if not clients:
+        raise ValueError("Arquivo de configuração não possui clientes cadastrados.")
+
+    return clients
+
+
+__all__ = ["ClientConfig", "AppConfig", "resolve_app_config", "load_clients", "load_environment"]

--- a/cpfl/pdf_parser.py
+++ b/cpfl/pdf_parser.py
@@ -1,0 +1,161 @@
+"""PDF parsing logic for CPFL invoices."""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import pdfplumber
+
+from .utils import (
+    decimal_to_string,
+    ensure_decimal_str,
+    ensure_numeric,
+    parse_decimal,
+    parse_date,
+    parse_month,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ParsedInvoice:
+    text: str
+    raw: Dict[str, Optional[str]]
+
+
+FIELD_PATTERNS: Dict[str, Iterable[re.Pattern[str]]] = {
+    "numero_instalacao": (
+        re.compile(r"instala[çc][aã]o[:\s]*([\d.]+)", re.I),
+        re.compile(r"n[úu]mero\s+da\s+instala[çc][aã]o[:\s]*([\d.]+)", re.I),
+    ),
+    "numero_cliente": (
+        re.compile(r"n[úu]mero\s+do\s+cliente[:\s]*([\d.]+)", re.I),
+        re.compile(r"c[óo]digo\s+do\s+cliente[:\s]*([\d.]+)", re.I),
+    ),
+    "mes_referencia": (
+        re.compile(r"conta\s*/?\s*m[eê]s[:\s]*([0-9/\-]+)", re.I),
+        re.compile(r"refer[êe]ncia[:\s]*([0-9/\-]+)", re.I),
+    ),
+    "vencimento": (
+        re.compile(r"vencimento[:\s]*([\d/\-]+)", re.I),
+        re.compile(r"data\s+de\s+vencimento[:\s]*([\d/\-]+)", re.I),
+    ),
+    "valor_total": (
+        re.compile(r"total\s+a\s+pagar[:\s]*(?:r\$\s*)?([\d.,]+)", re.I),
+        re.compile(r"valor\s+total\s+da\s+conta[:\s]*(?:r\$\s*)?([\d.,]+)", re.I),
+    ),
+    "consumo_kwh": (
+        re.compile(r"consumo.*?([\d.,]+)\s*kwh", re.I),
+        re.compile(r"quant\.?\s*consumida[:\s]*([\d.,]+)", re.I),
+    ),
+    "quantidade_faturada": (
+        re.compile(r"quant\.?\s*faturad[ao][:\s]*([\d.,]+)", re.I),
+    ),
+    "tarifa_com_tributos": (
+        re.compile(r"tarifa\s+com\s+tributos[:\s]*(?:r\$\s*)?([\d.,]+)", re.I),
+    ),
+    "valor_total_operacao": (
+        re.compile(r"valor\s+total\s+da\s+opera[cç][aã]o[:\s]*(?:r\$\s*)?([\d.,]+)", re.I),
+    ),
+    "bandeira_tarifaria": (
+        re.compile(r"bandeira\s+tarif[áa]ria[:\s]*([\w ]+)", re.I),
+    ),
+    "tusd": (
+        re.compile(r"tusd[:\s]*([\d.,]+)", re.I),
+    ),
+    "te": (
+        re.compile(r"t[eé][\s:]*([\d.,]+)", re.I),
+    ),
+    "icms": (
+        re.compile(r"icms[:\s]*([\d.,]+)", re.I),
+    ),
+    "pis_cofins": (
+        re.compile(r"pis\/?cofins[:\s]*([\d.,]+)", re.I),
+    ),
+    "endereco_uc": (
+        re.compile(r"endere[çc]o\s+da\s+unidade\s+consumidora[:\s]*(.+)", re.I),
+    ),
+    "status_pagamento": (
+        re.compile(r"status\s+do\s+pagamento[:\s]*(.+)", re.I),
+    ),
+    "link_pdf": (
+        re.compile(r"https?://\S+", re.I),
+    ),
+}
+
+
+def extract_text(pdf_path: Path) -> str:
+    text_segments = []
+    with pdfplumber.open(str(pdf_path)) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text() or ""
+            text_segments.append(text)
+    return "\n".join(text_segments)
+
+
+def parse_pdf(pdf_path: Path) -> ParsedInvoice:
+    LOGGER.info("Lendo PDF %s", pdf_path)
+    text = extract_text(pdf_path)
+    raw: Dict[str, Optional[str]] = {key: None for key in FIELD_PATTERNS}
+
+    for field, patterns in FIELD_PATTERNS.items():
+        for pattern in patterns:
+            matches = pattern.findall(text)
+            if not matches:
+                continue
+            value = matches[-1]
+            if isinstance(value, tuple):
+                value = value[0]
+            raw[field] = value.strip()
+            break
+
+    # Fallback for endereco: may span multiple lines
+    if not raw.get("endereco_uc"):
+        endereco_match = re.search(
+            r"endereço\s+da\s+unidade\s+consumidora[:\s]*(.+?)(?:\n\s*\n|status|valor total)",
+            text,
+            re.I | re.S,
+        )
+        if endereco_match:
+            raw["endereco_uc"] = re.sub(r"\s+", " ", endereco_match.group(1).strip())
+
+    processed: Dict[str, Optional[str]] = {}
+
+    processed["numero_instalacao"] = ensure_numeric(raw.get("numero_instalacao"))
+    processed["numero_cliente"] = ensure_numeric(raw.get("numero_cliente"))
+    processed["mes_referencia"] = parse_month(raw.get("mes_referencia")) or raw.get("mes_referencia")
+    processed["vencimento"] = parse_date(raw.get("vencimento")) or raw.get("vencimento")
+
+    for money_key in ("valor_total", "tusd", "te", "icms", "pis_cofins", "valor_total_operacao"):
+        value = parse_decimal(raw.get(money_key))
+        processed[money_key] = (
+            ensure_decimal_str(value) if value is not None else None
+        )
+
+    tarifa_valor = parse_decimal(raw.get("tarifa_com_tributos"), places=5)
+    processed["tarifa_com_tributos"] = (
+        ensure_decimal_str(tarifa_valor, places=5) if tarifa_valor is not None else None
+    )
+
+    processed["consumo_kwh"] = raw.get("consumo_kwh")
+    if processed["consumo_kwh"]:
+        processed["consumo_kwh"] = processed["consumo_kwh"].replace(",", ".")
+
+    quantidade = parse_decimal(raw.get("quantidade_faturada"), places=None)
+    processed["quantidade_faturada"] = (
+        decimal_to_string(quantidade) if quantidade is not None else None
+    )
+
+    processed["bandeira_tarifaria"] = raw.get("bandeira_tarifaria")
+    processed["endereco_uc"] = raw.get("endereco_uc")
+    processed["link_pdf"] = raw.get("link_pdf")
+    processed["status_pagamento"] = raw.get("status_pagamento")
+
+    return ParsedInvoice(text=text, raw=processed)
+
+
+__all__ = ["parse_pdf", "ParsedInvoice"]

--- a/cpfl/pipeline.py
+++ b/cpfl/pipeline.py
@@ -1,0 +1,97 @@
+"""Main pipeline orchestration."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+from .config import AppConfig, ClientConfig
+from .pdf_parser import parse_pdf
+from .storage import JsonWriter, MasterTable, build_invoice_row
+from .utils import merge_invoice_data, validate_invoice
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ProcessingResult:
+    novas: int = 0
+    atualizadas: int = 0
+    ignoradas: int = 0
+
+
+class InvoiceProcessor:
+    def __init__(self, app_config: AppConfig, clients: List[ClientConfig]) -> None:
+        self.app_config = app_config
+        self.clients = clients
+        self.master_table = MasterTable(app_config.master_table_path)
+        self.json_writer = JsonWriter(app_config.json_output_dir)
+
+    def run(self) -> ProcessingResult:
+        summary = ProcessingResult()
+        processed_rows: List[Dict[str, str]] = []
+
+        for client in self.clients:
+            client_dir = self._resolve_client_dir(client)
+            if not client_dir.exists():
+                LOGGER.warning("Pasta %s não existe para o cliente %s", client_dir, client.cliente)
+                continue
+
+            for pdf_file in sorted(client_dir.glob("*.pdf")):
+                invoice = self._process_pdf(client, pdf_file)
+                if invoice is None:
+                    summary.ignoradas += 1
+                    continue
+                processed_rows.append(invoice)
+
+        result = self.master_table.upsert_rows(processed_rows)
+        summary.novas += result.get("novas", 0)
+        summary.atualizadas += result.get("atualizadas", 0)
+        summary.ignoradas += result.get("ignoradas", 0)
+
+        self.master_table.save()
+        self.master_table.save_excel(self.app_config.master_excel_path)
+
+        return summary
+
+    def _resolve_client_dir(self, client: ClientConfig) -> Path:
+        if client.pasta_entrada:
+            return Path(client.pasta_entrada)
+        return self.app_config.inbox_dir / client.slug
+
+    def _process_pdf(self, client: ClientConfig, pdf_path: Path) -> Dict[str, str] | None:
+        LOGGER.info("Processando %s para cliente %s", pdf_path, client.cliente)
+        parsed = parse_pdf(pdf_path)
+
+        invoice_data = merge_invoice_data({}, parsed.raw)
+        invoice_data["numero_instalacao"] = invoice_data.get("numero_instalacao") or client.numero_instalacao
+        invoice_data["numero_cliente"] = invoice_data.get("numero_cliente") or client.numero_cliente
+
+        if not validate_invoice(invoice_data):
+            LOGGER.error("Fatura %s não passou na validação", pdf_path)
+            return None
+
+        destination = self._archive_file(pdf_path)
+        invoice_row = build_invoice_row(client.cliente, invoice_data, destination)
+        self.json_writer.write(invoice_row)
+        return invoice_row
+
+    def _archive_file(self, pdf_path: Path) -> Path:
+        archive_dir = self.app_config.archive_dir
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        destination = archive_dir / pdf_path.name
+        if destination.exists():
+            counter = 1
+            while True:
+                candidate = archive_dir / f"{pdf_path.stem}_dup{counter}{pdf_path.suffix}"
+                if not candidate.exists():
+                    destination = candidate
+                    break
+                counter += 1
+        pdf_path.rename(destination)
+        LOGGER.info("Arquivo %s arquivado em %s", pdf_path, destination)
+        return destination
+
+
+__all__ = ["InvoiceProcessor", "ProcessingResult"]

--- a/cpfl/storage.py
+++ b/cpfl/storage.py
@@ -1,0 +1,123 @@
+"""Persistence helpers for CPFL invoices."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+
+from .utils import compute_invoice_hash
+
+LOGGER = logging.getLogger(__name__)
+
+MASTER_COLUMNS = [
+    "cliente",
+    "numero_instalacao",
+    "numero_cliente",
+    "mes_referencia",
+    "vencimento",
+    "valor_total",
+    "consumo_kwh",
+    "quantidade_faturada",
+    "tarifa_com_tributos",
+    "valor_total_operacao",
+    "bandeira_tarifaria",
+    "tusd",
+    "te",
+    "icms",
+    "pis_cofins",
+    "endereco_uc",
+    "link_pdf",
+    "hash_fatura",
+    "status_pagamento",
+    "arquivo_origem",
+]
+
+
+class MasterTable:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        if self.path.exists():
+            self.df = pd.read_csv(self.path, dtype=str)
+        else:
+            self.df = pd.DataFrame(columns=MASTER_COLUMNS)
+
+    def lookup_hashes(self) -> set:
+        hashes = set(self.df.get("hash_fatura", pd.Series(dtype=str)).dropna().tolist())
+        return hashes
+
+    def upsert_rows(self, rows: List[Dict[str, Optional[str]]]) -> Dict[str, int]:
+        if not rows:
+            return {"novas": 0, "atualizadas": 0, "ignoradas": 0}
+
+        existing_hashes = self.lookup_hashes()
+        new_rows = []
+        updated_rows = 0
+        ignored_rows = 0
+
+        for row in rows:
+            invoice_hash = row.get("hash_fatura")
+            if not invoice_hash:
+                continue
+            mask = self.df["hash_fatura"] == invoice_hash
+            if mask.any():
+                index = self.df[mask].index[0]
+                self.df.loc[index] = row
+                updated_rows += 1
+            elif invoice_hash not in existing_hashes:
+                new_rows.append(row)
+            else:
+                ignored_rows += 1
+
+        if new_rows:
+            new_df = pd.DataFrame(new_rows)
+            self.df = pd.concat([self.df, new_df], ignore_index=True)
+
+        return {"novas": len(new_rows), "atualizadas": updated_rows, "ignoradas": ignored_rows}
+
+    def save(self) -> None:
+        self.df = self.df.sort_values(["cliente", "numero_instalacao", "mes_referencia"])
+        self.df.to_csv(self.path, index=False)
+
+    def save_excel(self, path: Path) -> None:
+        self.df.to_excel(path, index=False)
+
+
+class JsonWriter:
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def write(self, invoice: Dict[str, Optional[str]]) -> Path:
+        invoice_hash = invoice.get("hash_fatura")
+        filename = f"{invoice_hash}.json" if invoice_hash else "invoice.json"
+        path = self.output_dir / filename
+        with path.open("w", encoding="utf-8") as fp:
+            json.dump(invoice, fp, ensure_ascii=False, indent=2)
+        return path
+
+
+def build_invoice_row(cliente: str, invoice: Dict[str, Optional[str]], source_file: Path) -> Dict[str, Optional[str]]:
+    data = {column: None for column in MASTER_COLUMNS}
+    data.update(invoice)
+    data["cliente"] = cliente
+    data["hash_fatura"] = compute_invoice_hash(
+        invoice.get("numero_instalacao", ""),
+        invoice.get("mes_referencia", ""),
+        invoice.get("valor_total", "0"),
+    )
+    data["arquivo_origem"] = str(source_file)
+    return data
+
+
+def write_summary_log(summary: Dict[str, int]) -> str:
+    return (
+        f"Faturas novas: {summary.get('novas', 0)} | "
+        f"Atualizadas: {summary.get('atualizadas', 0)} | "
+        f"Ignoradas: {summary.get('ignoradas', 0)}"
+    )
+
+
+__all__ = ["MasterTable", "JsonWriter", "build_invoice_row", "write_summary_log", "MASTER_COLUMNS"]

--- a/cpfl/utils.py
+++ b/cpfl/utils.py
@@ -1,0 +1,212 @@
+"""Utility functions for parsing and normalization."""
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from datetime import datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Dict, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+DECIMAL_RE = re.compile(r"[-+]?\d+[\d.,]*")
+DATE_RE = re.compile(r"(\d{1,2})[\-/](\d{1,2})[\-/](\d{2,4})")
+MONTH_RE = re.compile(r"(\d{1,2})[\-/](\d{2,4})")
+
+
+def clean_number(value: str) -> str:
+    digits = re.sub(r"\D", "", value)
+    return digits
+
+
+def parse_decimal(value: Optional[str], places: Optional[int] = 2) -> Optional[Decimal]:
+    if not value:
+        return None
+    normalized = value.replace("R$", "").replace(" ", "")
+    normalized = normalized.replace(".", "").replace(",", ".")
+    try:
+        decimal_value = Decimal(normalized)
+    except (InvalidOperation, ValueError) as exc:
+        LOGGER.debug("Unable to parse decimal from %s: %s", value, exc)
+        return None
+    if places is None:
+        return decimal_value
+    quantizer = Decimal(1) / (Decimal(10) ** places)
+    return decimal_value.quantize(quantizer, rounding=ROUND_HALF_UP)
+
+
+def parse_month(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    match = MONTH_RE.search(value)
+    if not match:
+        return None
+    month = int(match.group(1))
+    year = match.group(2)
+    if len(year) == 2:
+        year = f"20{year}"
+    return f"{month:02d}/{year}"
+
+
+def parse_date(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    match = DATE_RE.search(value)
+    if not match:
+        return None
+    day = int(match.group(1))
+    month = int(match.group(2))
+    year = match.group(3)
+    if len(year) == 2:
+        year = f"20{year}"
+    try:
+        parsed = datetime(int(year), month, day)
+    except ValueError as exc:
+        LOGGER.debug("Invalid date %s: %s", value, exc)
+        return None
+    return parsed.strftime("%d/%m/%Y")
+
+
+def compute_invoice_hash(numero_instalacao: str, mes_referencia: str, valor_total: str) -> str:
+    raw = f"{numero_instalacao}|{mes_referencia}|{valor_total}"
+    return hashlib.md5(raw.encode("utf-8")).hexdigest()
+
+
+def ensure_decimal_str(value: Optional[Decimal], places: int = 2) -> Optional[str]:
+    if value is None:
+        return None
+    pattern = f"{{0:.{places}f}}"
+    return pattern.format(value)
+
+
+def decimal_to_string(value: Optional[Decimal]) -> Optional[str]:
+    if value is None:
+        return None
+    normalized = value.normalize()
+    text = format(normalized, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text
+
+
+def ensure_numeric(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    digits = clean_number(value)
+    return digits or None
+
+
+def validate_invoice(invoice: Dict[str, Any]) -> bool:
+    """Perform basic validation checks."""
+
+    valor_total = invoice.get("valor_total")
+    consumo_kwh = invoice.get("consumo_kwh")
+    mes_referencia = invoice.get("mes_referencia")
+    vencimento = invoice.get("vencimento")
+
+    try:
+        if valor_total is not None and Decimal(str(valor_total)) <= 0:
+            LOGGER.warning("Valor total inválido: %s", valor_total)
+            return False
+    except InvalidOperation:
+        LOGGER.warning("Valor total não numérico: %s", valor_total)
+        return False
+
+    if consumo_kwh is not None:
+        try:
+            if Decimal(str(consumo_kwh)) < 0:
+                LOGGER.warning("Consumo negativo: %s", consumo_kwh)
+                return False
+        except InvalidOperation:
+            LOGGER.warning("Consumo não numérico: %s", consumo_kwh)
+            return False
+
+    if mes_referencia is None:
+        LOGGER.warning("Mês de referência ausente")
+        return False
+
+    if vencimento is not None:
+        parsed = parse_date(vencimento)
+        if not parsed:
+            LOGGER.warning("Data de vencimento inválida: %s", vencimento)
+            return False
+        invoice["vencimento"] = parsed
+
+    # Reformat month to ensure normalization
+    normalized_month = parse_month(mes_referencia)
+    if not normalized_month:
+        LOGGER.warning("Mês de referência inválido: %s", mes_referencia)
+        return False
+    invoice["mes_referencia"] = normalized_month
+
+    decimal_fields = {
+        "valor_total": 2,
+        "tusd": 2,
+        "te": 2,
+        "icms": 2,
+        "pis_cofins": 2,
+        "valor_total_operacao": 2,
+    }
+    for key, places in decimal_fields.items():
+        if invoice.get(key) is None:
+            continue
+        try:
+            invoice[key] = ensure_decimal_str(Decimal(str(invoice[key])), places=places)
+        except InvalidOperation:
+            LOGGER.warning("Valor inválido para %s: %s", key, invoice.get(key))
+            invoice[key] = None
+
+    if invoice.get("tarifa_com_tributos") is not None:
+        try:
+            valor_tarifa = Decimal(str(invoice["tarifa_com_tributos"]))
+            invoice["tarifa_com_tributos"] = ensure_decimal_str(valor_tarifa, places=5)
+        except InvalidOperation:
+            LOGGER.warning(
+                "Tarifa com tributos inválida: %s", invoice.get("tarifa_com_tributos")
+            )
+            invoice["tarifa_com_tributos"] = None
+
+    if invoice.get("consumo_kwh") is not None:
+        try:
+            invoice["consumo_kwh"] = str(Decimal(str(invoice["consumo_kwh"])))
+        except InvalidOperation:
+            invoice["consumo_kwh"] = None
+
+    if invoice.get("quantidade_faturada") is not None:
+        try:
+            quantidade = Decimal(str(invoice["quantidade_faturada"]))
+            if quantidade < 0:
+                LOGGER.warning(
+                    "Quantidade faturada negativa: %s", invoice["quantidade_faturada"]
+                )
+                return False
+            invoice["quantidade_faturada"] = decimal_to_string(quantidade)
+        except InvalidOperation:
+            LOGGER.warning(
+                "Quantidade faturada inválida: %s", invoice.get("quantidade_faturada")
+            )
+            invoice["quantidade_faturada"] = None
+
+    return True
+
+
+def merge_invoice_data(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
+    result = base.copy()
+    for key, value in updates.items():
+        if value not in (None, ""):
+            result[key] = value
+    return result
+
+
+__all__ = [
+    "parse_decimal",
+    "parse_date",
+    "parse_month",
+    "compute_invoice_hash",
+    "ensure_decimal_str",
+    "ensure_numeric",
+    "validate_invoice",
+    "merge_invoice_data",
+]

--- a/data/mocks/README.md
+++ b/data/mocks/README.md
@@ -1,0 +1,9 @@
+# Mocks de Faturas CPFL
+
+PDFs fictícios usados para testes offline sem credenciais reais. Copie-os para a pasta configurada de entrada (`data/incoming/cliente_teste/`) antes de rodar `python main.py sync`.
+
+Arquivos disponíveis:
+
+- `fatura_2023-05.pdf`
+- `fatura_2023-06.pdf`
+- `fatura_2025-08.pdf` *(estrutura alinhada ao layout com campos "Instalação", "Conta/Mês", "Quant. Faturada", "Tarifa com Tributos" e "Valor Total da Operação" para validar as novas extrações).* 

--- a/data/mocks/cliente_teste/fatura_2023-05.pdf
+++ b/data/mocks/cliente_teste/fatura_2023-05.pdf
@@ -1,0 +1,65 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 577 >>
+stream
+BT
+/F1 12 Tf
+14 TL
+72 780 Td
+(Conta de Energia - CPFL) Tj
+T*
+(Numero da Instalacao: 1234567890) Tj
+T*
+(Numero do Cliente: 9876543210) Tj
+T*
+(Mes de Referencia: 05/2023) Tj
+T*
+(Vencimento: 15/06/2023) Tj
+T*
+(Valor Total \(R$\): 245,67) Tj
+T*
+(Consumo \(kWh\): 320) Tj
+T*
+(Bandeira Tarifaria: Verde) Tj
+T*
+(TUSD: 120,45) Tj
+T*
+(TE: 100,34) Tj
+T*
+(ICMS: 20,00) Tj
+T*
+(PIS/COFINS: 5,00) Tj
+T*
+(Endereco da Unidade Consumidora: Rua Exemplo, 123 - Centro - São José do Rio Preto/SP) Tj
+T*
+(Status do Pagamento: Pago) Tj
+T*
+(https://exemplo.com/faturas/1234567890-2023-05.pdf) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000869 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+939
+%%EOF

--- a/data/mocks/cliente_teste/fatura_2023-06.pdf
+++ b/data/mocks/cliente_teste/fatura_2023-06.pdf
@@ -1,0 +1,65 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 584 >>
+stream
+BT
+/F1 12 Tf
+14 TL
+72 780 Td
+(Conta de Energia - CPFL) Tj
+T*
+(Numero da Instalacao: 1234567890) Tj
+T*
+(Numero do Cliente: 9876543210) Tj
+T*
+(Mes de Referencia: 06/2023) Tj
+T*
+(Vencimento: 15/07/2023) Tj
+T*
+(Valor Total \(R$\): 310,12) Tj
+T*
+(Consumo \(kWh\): 410) Tj
+T*
+(Bandeira Tarifaria: Amarela) Tj
+T*
+(TUSD: 150,00) Tj
+T*
+(TE: 120,00) Tj
+T*
+(ICMS: 30,00) Tj
+T*
+(PIS/COFINS: 7,50) Tj
+T*
+(Endereco da Unidade Consumidora: Rua Exemplo, 123 - Centro - São José do Rio Preto/SP) Tj
+T*
+(Status do Pagamento: Em aberto) Tj
+T*
+(https://exemplo.com/faturas/1234567890-2023-06.pdf) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000876 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+946
+%%EOF

--- a/data/mocks/cliente_teste/fatura_2025-08.pdf
+++ b/data/mocks/cliente_teste/fatura_2025-08.pdf
@@ -1,0 +1,60 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 498 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(Instalao: 8367800042) Tj
+0 -14 Td
+(Conta/Ms: AGO/2025) Tj
+0 -14 Td
+(Vencimento: 15/09/2025) Tj
+0 -14 Td
+(Total a Pagar: R$ 94,42) Tj
+0 -14 Td
+(Quant. Faturada: 108 kWh) Tj
+0 -14 Td
+(Tarifa com Tributos: R$ 0,87410) Tj
+0 -14 Td
+(Valor Total da Operao: R$ 94,42) Tj
+0 -14 Td
+(Nmero do Cliente: 710877927) Tj
+0 -14 Td
+(Bandeira Tarifria: Amarela) Tj
+0 -14 Td
+(TUSD: R$ 45,11) Tj
+0 -14 Td
+(TE: R$ 39,31) Tj
+0 -14 Td
+(ICMS: R$ 8,50) Tj
+0 -14 Td
+(PIS/COFINS: R$ 1,50) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000790 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+860
+%%EOF

--- a/main.py
+++ b/main.py
@@ -1,0 +1,51 @@
+"""Command line runner for CPFL invoice processing."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from cpfl.config import load_clients, resolve_app_config
+from cpfl.pipeline import InvoiceProcessor
+
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+def setup_logging(verbose: bool = False) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format=LOG_FORMAT)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Processa faturas da CPFL a partir de PDFs.")
+    parser.add_argument("command", choices=["sync"], help="Comando a executar.")
+    parser.add_argument("--config", dest="config", help="Caminho do arquivo de configuração de clientes.")
+    parser.add_argument("--verbose", action="store_true", help="Habilita logs detalhados.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    setup_logging(args.verbose)
+
+    if args.command != "sync":
+        raise ValueError("Comando desconhecido. Use 'sync'.")
+
+    app_config = resolve_app_config(args.config)
+    clients = load_clients(app_config.config_path)
+
+    processor = InvoiceProcessor(app_config, clients)
+    summary = processor.run()
+
+    logging.info(
+        "Resumo: novas=%s atualizadas=%s ignoradas=%s",
+        summary.novas,
+        summary.atualizadas,
+        summary.ignoradas,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pdfplumber==0.10.3
+pandas==2.1.4
+python-dotenv==1.0.0
+openpyxl==3.1.2


### PR DESCRIPTION
## Summary
- ajustar o parser de PDFs para reconhecer campos como "Conta/Mês", "Total a Pagar", "Quant. Faturada", "Tarifa com Tributos" e "Valor Total da Operação"
- atualizar utilitários e schema para tratar novas colunas com validação e formatação de casas decimais
- documentar as novas saídas e incluir um mock PDF alinhado ao layout recente da CPFL para testes offline

## Testing
- ⚠️ `pip install -r requirements.txt` *(falhou: proxy bloqueou o download de pdfplumber)*

------
https://chatgpt.com/codex/tasks/task_e_68dae80519f48333b15d12738b1d9f3e